### PR TITLE
fix issue with BitBucket downloads

### DIFF
--- a/src/main/java/org/jmeterplugins/repository/JARSourceHTTP.java
+++ b/src/main/java/org/jmeterplugins/repository/JARSourceHTTP.java
@@ -229,6 +229,9 @@ public class JARSourceHTTP extends JARSource {
             String filename;
             if (cd != null) {
                 filename = cd.getValue().split(";")[1].split("=")[1];
+                if (filename.length() > 2 && filename.startsWith("\"") && filename.endsWith("\"")) {
+                    filename = filename.substring(1, filename.length() - 1);
+                }
             } else {
                 HttpUriRequest currentReq = (HttpUriRequest) context.getAttribute(ExecutionContext.HTTP_REQUEST);
                 HttpHost currentHost = (HttpHost) context.getAttribute(ExecutionContext.HTTP_TARGET_HOST);


### PR DESCRIPTION
BitBucket downloads appear to have a content-disposition header value where the filename is quoted. This causes copying the downloaded file to JMeter lib/ext directory to fail.
In order to prevent this, this commit discard the quotes when the filename from content-disposition header is wrapped in quotes.