### PR TITLE
Fix Invalid use of BasicClientConnManager: connection still allocated.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,5 +148,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-manager</artifactId>
-    <version>0.15</version>
+    <version>0.17</version>
 
     <name>JMeter Plugins Manager</name>
     <description>UI-based plugins management</description>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>jmeter-plugins-manager</artifactId>
-    <version>0.17</version>
+    <version>0.15</version>
 
     <name>JMeter Plugins Manager</name>
     <description>UI-based plugins management</description>

--- a/src/main/java/org/jmeterplugins/repository/JARSourceHTTP.java
+++ b/src/main/java/org/jmeterplugins/repository/JARSourceHTTP.java
@@ -283,6 +283,8 @@ public class JARSourceHTTP extends JARSource {
         HttpContext context = new BasicHttpContext();
         HttpResponse response = execute(httpget, context);
         if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+            log.error("Error downloading url:"+url+" got response code:"+response.getStatusLine().getStatusCode());
+            EntityUtils.consumeQuietly(response.getEntity());
             throw new IOException(response.getStatusLine().toString());
         }
 

--- a/src/main/java/org/jmeterplugins/repository/JARSourceHTTP.java
+++ b/src/main/java/org/jmeterplugins/repository/JARSourceHTTP.java
@@ -283,8 +283,8 @@ public class JARSourceHTTP extends JARSource {
         HttpContext context = new BasicHttpContext();
         HttpResponse response = execute(httpget, context);
         if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-            //log.error("Error downloading url:"+url+" got response code:"+response.getStatusLine().getStatusCode());
-            //EntityUtils.consumeQuietly(response.getEntity());
+            log.error("Error downloading url:"+url+" got response code:"+response.getStatusLine().getStatusCode());
+            EntityUtils.consumeQuietly(response.getEntity());
             throw new IOException(response.getStatusLine().toString());
         }
 

--- a/src/main/java/org/jmeterplugins/repository/JARSourceHTTP.java
+++ b/src/main/java/org/jmeterplugins/repository/JARSourceHTTP.java
@@ -283,8 +283,8 @@ public class JARSourceHTTP extends JARSource {
         HttpContext context = new BasicHttpContext();
         HttpResponse response = execute(httpget, context);
         if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
-            log.error("Error downloading url:"+url+" got response code:"+response.getStatusLine().getStatusCode());
-            EntityUtils.consumeQuietly(response.getEntity());
+            //log.error("Error downloading url:"+url+" got response code:"+response.getStatusLine().getStatusCode());
+            //EntityUtils.consumeQuietly(response.getEntity());
             throw new IOException(response.getStatusLine().toString());
         }
 


### PR DESCRIPTION
When you face an error in some download the plugin is completely broken with :
2017-12-02 21:30:36,492 ERROR o.j.r.PluginManager: Failed to download jna
java.lang.IllegalStateException: Invalid use of BasicClientConnManager: connection still allocated.
Make sure to release the connection before allocating another one.
	at org.apache.http.util.Asserts.check(Asserts.java:34) ~[httpcore-4.4.7.jar:4.4.7]
	at org.apache.http.impl.conn.BasicClientConnectionManager.getConnection(BasicClientConnectionManager.java:163) ~[httpclient-4.5.3.jar:4.5.3]
	at org.apache.http.impl.conn.BasicClientConnectionManager$1.getConnection(BasicClientConnectionManager.java:145) ~[httpclient-4.5.3.jar:4.5.3]
	at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:422) ~[httpclient-4.5.3.jar:4.5.3]
	at org.apache.http.impl.client.AbstractHttpClient.doExecute(AbstractHttpClient.java:835) ~[httpclient-4.5.3.jar:4.5.3]
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83) ~[httpclient-4.5.3.jar:4.5.3]
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56) ~[httpclient-4.5.3.jar:4.5.3]
	at org.jmeterplugins.repository.JARSourceHTTP.execute(JARSourceHTTP.java:376) ~[jmeter-plugins-manager-0.16.jar:?]
	at org.jmeterplugins.repository.JARSourceHTTP.getJAR(JARSourceHTTP.java:284) ~[jmeter-plugins-manager-0.16.jar:?]
	at org.jmeterplugins.repository.PluginManager.applyChanges(PluginManager.java:163) [jmeter-plugins-manager-0.16.jar:?]
	at org.jmeterplugins.repository.PluginManagerDialog$4.run(PluginManagerDialog.java:226) [jmeter-plugins-manager-0.16.jar:?]
