### PR TITLE
Sanitize temp filename prefix

### DIFF
--- a/src/main/java/org/jmeterplugins/repository/JARSourceHTTP.java
+++ b/src/main/java/org/jmeterplugins/repository/JARSourceHTTP.java
@@ -395,7 +395,7 @@ public class JARSourceHTTP extends JARSource {
 
         HttpEntity entity = response.getEntity();
 
-        File tempFile = File.createTempFile(id, ".jar");
+        File tempFile = File.createTempFile(id.replaceAll("[^a-zA-Z0-9\\._]+", "_"), ".jar");
 
         final long size = entity.getContentLength();
 


### PR DESCRIPTION
This fixes an issue when downloading plugins with ids that contain characters the filesystem doesn't like (e.g. `cmdrunner>=2.2` is an illegal Windows filename).