### PR TITLE
Fix NPE issue with future version 5.3 of JMeter

### DIFF
--- a/src/main/java/org/jmeterplugins/repository/CheckBoxList.java
+++ b/src/main/java/org/jmeterplugins/repository/CheckBoxList.java
@@ -28,13 +28,20 @@ public class CheckBoxList<T extends JCheckBox> extends JList<T> {
 
                                  if (index != -1) {
                                      JCheckBox checkbox = getModel().getElementAt(index);
-                                     Icon i = UIManager.getIcon("CheckBox.icon");
-                                     if (e.getX() <= i.getIconWidth() + xOffset) {
-                                         if (checkbox.isEnabled()) {
+                                     Icon icon = UIManager.getIcon("CheckBox.icon");
+                                     if (icon != null) {
+	                                     if (e.getX() <= icon.getIconWidth() + xOffset) {
+	                                         if (checkbox.isEnabled()) {
+	                                             checkbox.setSelected(!checkbox.isSelected());
+	                                         }
+	                                     }
+	                                     repaint();
+                                     } else {
+                                    	 if (checkbox.isEnabled()) {
                                              checkbox.setSelected(!checkbox.isSelected());
                                          }
+                                    	 repaint();
                                      }
-                                     repaint();
                                  }
                              }
                          }


### PR DESCRIPTION
Hello @undera ,
Future JMeter 5.3 contains many changes related to LAF.
I tested jpm with it, and we get NPE when selecting a checkbox.
This is due to missing CheckBox.icon in some LAF (Darklaf).
So I added a null check.

Regards
Philippe M.
[UbikLoadPack](https://ubikloadpack.com/) Team