### PR TITLE
Run in headless mode on Windows

### DIFF
--- a/src/main/resources/org/jmeterplugins/repository/PluginsManagerCMD.bat
+++ b/src/main/resources/org/jmeterplugins/repository/PluginsManagerCMD.bat
@@ -1,3 +1,3 @@
 @echo off
 
-java %JVM_ARGS% -jar "%~dp0\..\lib\cmdrunner-2.3.jar" --tool org.jmeterplugins.repository.PluginManagerCMD %*
+java "-Djava.awt.headless=true" %JVM_ARGS% -jar "%~dp0\..\lib\cmdrunner-2.3.jar" --tool org.jmeterplugins.repository.PluginManagerCMD %*


### PR DESCRIPTION
Hi @undera 

Doing some work around Taurus and other tools that use the plugin manager behind, I came across a plugin that is causing problems on Windows OS version.
Analyzing why this problem does not occur in Linux and Mac, I find that the difference is that in both Mac and Linux the command runs in awt headless mode true and in Windows the execution does not have that parameter assigned.
Therefore when a plugin in installation mode displays an informational dialog, the dialog will block execution.

The proposed change is like .sh version, the windows version need to run with awt headless mode in true.
