### PR TITLE
Add BackendListener impl class to nonExistentClasses while analyzing test plan

### DIFF
--- a/src/main/java/org/jmeterplugins/repository/plugins/TestPlanAnalyzer.java
+++ b/src/main/java/org/jmeterplugins/repository/plugins/TestPlanAnalyzer.java
@@ -43,6 +43,10 @@ public class TestPlanAnalyzer {
                 NamedNodeMap attributes = node.getAttributes();
                 checkAttributeAndAdd(attributes, "guiclass", nonExistentClasses);
                 checkAttributeAndAdd(attributes, "testclass", nonExistentClasses);
+
+                if (node.getNodeName().equals("BackendListener")) {
+                    addBackendListenerImplClass(node, nonExistentClasses);
+                }
             }
             return nonExistentClasses;
         }
@@ -53,6 +57,20 @@ public class TestPlanAnalyzer {
         Node node = attributes.getNamedItem(attributeName);
         if (node != null && !isClassExists(node.getTextContent())) {
             nonExistentClasses.add(node.getTextContent());
+        }
+    }
+
+    // BackendListener has implementation class stored in a stringProp with name="classname"
+    private void addBackendListenerImplClass(Node node, final Set<String> nonExistentClasses) {
+        NodeList children = node.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node child = children.item(i);
+            if (child.getNodeName().equals("stringProp")) {
+               Node name = child.getAttributes().getNamedItem("name");
+               if (name != null && name.getTextContent().equals("classname") && !isClassExists(child.getTextContent())) {
+                   nonExistentClasses.add(child.getTextContent());
+                }
+            }
         }
     }
 

--- a/src/test/java/org/jmeterplugins/repository/plugins/TestPlanAnalyzerTest.java
+++ b/src/test/java/org/jmeterplugins/repository/plugins/TestPlanAnalyzerTest.java
@@ -28,4 +28,18 @@ public class TestPlanAnalyzerTest {
         assertTrue(classes.contains("kg.apc.jmeter.vizualizers.CorrectedResultCollector"));
         assertTrue(classes.contains("kg.apc.jmeter.samplers.DummySamplerGui"));
     }
+
+    @Test
+    public void testBackendListenerImpl() throws Exception {
+        String path = getClass().getResource("/testplan-with-backend-listener.xml").getPath();
+        TestPlanAnalyzer analyzer = new TestPlanAnalyzer();
+        Set<String> classes = analyzer.analyze(path);
+
+        assertEquals(5, classes.size());
+        assertTrue(classes.contains("kg.apc.jmeter.vizualizers.ResponseTimesOverTimeGui"));
+        assertTrue(classes.contains("kg.apc.jmeter.samplers.DummySampler"));
+        assertTrue(classes.contains("kg.apc.jmeter.vizualizers.CorrectedResultCollector"));
+        assertTrue(classes.contains("kg.apc.jmeter.samplers.DummySamplerGui"));
+        assertTrue(classes.contains("io.github.adrianmo.jmeter.backendlistener.azure.AzureBackendClient"));
+    }
 }

--- a/src/test/resources/testplan-with-backend-listener.xml
+++ b/src/test/resources/testplan-with-backend-listener.xml
@@ -1,0 +1,179 @@
+<?xml   version='1.0' encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="3.2" jmeter="3.2 r1790748">
+    <hashTree>
+        <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
+            <stringProp name="TestPlan.comments"></stringProp>
+            <boolProp name="TestPlan.functional_mode">false</boolProp>
+            <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+            <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+                <collectionProp name="Arguments.arguments"/>
+            </elementProp>
+            <stringProp name="TestPlan.user_define_classpath"></stringProp>
+        </TestPlan>
+        <hashTree>
+            <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
+                <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+                <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+                    <boolProp name="LoopController.continue_forever">false</boolProp>
+                    <stringProp name="LoopController.loops">10</stringProp>
+                </elementProp>
+                <stringProp name="ThreadGroup.num_threads">1</stringProp>
+                <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+                <longProp name="ThreadGroup.start_time">1500968737000</longProp>
+                <longProp name="ThreadGroup.end_time">1500968737000</longProp>
+                <boolProp name="ThreadGroup.scheduler">false</boolProp>
+                <stringProp name="ThreadGroup.duration"></stringProp>
+                <stringProp name="ThreadGroup.delay"></stringProp>
+            </ThreadGroup>
+            <hashTree>
+                <DebugSampler guiclass="TestBeanGUI" testclass="DebugSampler" testname="Debug Sampler &#x12;" enabled="true">
+                    <boolProp name="displayJMeterProperties">false</boolProp>
+                    <boolProp name="displayJMeterVariables">true</boolProp>
+                    <boolProp name="displaySystemProperties">false</boolProp>
+                </DebugSampler>
+                <hashTree/>
+                <kg.apc.jmeter.samplers.DummySampler guiclass="kg.apc.jmeter.samplers.DummySamplerGui" testclass="kg.apc.jmeter.samplers.DummySampler" testname="jp@gc - Dummy Sampler" enabled="true">
+                    <boolProp name="WAITING">true</boolProp>
+                    <boolProp name="SUCCESFULL">true</boolProp>
+                    <stringProp name="RESPONSE_CODE">200</stringProp>
+                    <stringProp name="RESPONSE_MESSAGE">OK</stringProp>
+                    <stringProp name="REQUEST_DATA">Dummy Sampler used to simulate requests and responses
+                        without actual network activity. This helps debugging tests.</stringProp>
+                    <stringProp name="RESPONSE_DATA">Dummy Sampler used to simulate requests and responses
+                        without actual network activity. This helps debugging tests.</stringProp>
+                    <stringProp name="RESPONSE_TIME">${__Random(50,500)}</stringProp>
+                    <stringProp name="LATENCY">${__Random(1,50)}</stringProp>
+                    <stringProp name="CONNECT">${__Random(1,5)}</stringProp>
+                </kg.apc.jmeter.samplers.DummySampler>
+                <hashTree/>
+                <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+                    <boolProp name="ResultCollector.error_logging">false</boolProp>
+                    <objProp>
+                        <name>saveConfig</name>
+                        <value class="SampleSaveConfiguration">
+                            <time>true</time>
+                            <latency>true</latency>
+                            <timestamp>true</timestamp>
+                            <success>true</success>
+                            <label>true</label>
+                            <code>true</code>
+                            <message>true</message>
+                            <threadName>true</threadName>
+                            <dataType>true</dataType>
+                            <encoding>false</encoding>
+                            <assertions>true</assertions>
+                            <subresults>true</subresults>
+                            <responseData>false</responseData>
+                            <samplerData>false</samplerData>
+                            <xml>false</xml>
+                            <fieldNames>true</fieldNames>
+                            <responseHeaders>false</responseHeaders>
+                            <requestHeaders>false</requestHeaders>
+                            <responseDataOnError>false</responseDataOnError>
+                            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+                            <assertionsResultsToSave>0</assertionsResultsToSave>
+                            <bytes>true</bytes>
+                            <sentBytes>true</sentBytes>
+                            <threadCounts>true</threadCounts>
+                            <idleTime>true</idleTime>
+                            <connectTime>true</connectTime>
+                        </value>
+                    </objProp>
+                    <stringProp name="filename"></stringProp>
+                </ResultCollector>
+                <hashTree/>
+                <kg.apc.jmeter.vizualizers.CorrectedResultCollector guiclass="kg.apc.jmeter.vizualizers.ResponseTimesOverTimeGui" testclass="kg.apc.jmeter.vizualizers.CorrectedResultCollector" testname="jp@gc - Response Times Over Time" enabled="true">
+                    <boolProp name="ResultCollector.error_logging">false</boolProp>
+                    <objProp>
+                        <name>saveConfig</name>
+                        <value class="SampleSaveConfiguration">
+                            <time>true</time>
+                            <latency>true</latency>
+                            <timestamp>true</timestamp>
+                            <success>true</success>
+                            <label>true</label>
+                            <code>true</code>
+                            <message>true</message>
+                            <threadName>true</threadName>
+                            <dataType>true</dataType>
+                            <encoding>false</encoding>
+                            <assertions>true</assertions>
+                            <subresults>true</subresults>
+                            <responseData>false</responseData>
+                            <samplerData>false</samplerData>
+                            <xml>false</xml>
+                            <fieldNames>true</fieldNames>
+                            <responseHeaders>false</responseHeaders>
+                            <requestHeaders>false</requestHeaders>
+                            <responseDataOnError>false</responseDataOnError>
+                            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+                            <assertionsResultsToSave>0</assertionsResultsToSave>
+                            <bytes>true</bytes>
+                            <sentBytes>true</sentBytes>
+                            <threadCounts>true</threadCounts>
+                            <idleTime>true</idleTime>
+                            <connectTime>true</connectTime>
+                        </value>
+                    </objProp>
+                    <stringProp name="filename"></stringProp>
+                    <longProp name="interval_grouping">500</longProp>
+                    <boolProp name="graph_aggregated">false</boolProp>
+                    <stringProp name="include_sample_labels"></stringProp>
+                    <stringProp name="exclude_sample_labels"></stringProp>
+                    <stringProp name="start_offset"></stringProp>
+                    <stringProp name="end_offset"></stringProp>
+                    <boolProp name="include_checkbox_state">false</boolProp>
+                    <boolProp name="exclude_checkbox_state">false</boolProp>
+                </kg.apc.jmeter.vizualizers.CorrectedResultCollector>
+                <hashTree/>
+                <BackendListener guiclass="BackendListener" testclass="BackendListener" testname="Backend Listener" enabled="true">
+                    <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
+                        <collectionProp name="Arguments.arguments">
+                            <elementProp name="testName" elementType="Argument">
+                                <stringProp name="Argument.name">testName</stringProp>
+                                <stringProp name="Argument.value">jmeter</stringProp>
+                                <stringProp name="Argument.metadata">=</stringProp>
+                            </elementProp>
+                            <elementProp name="connectionString" elementType="Argument">
+                                <stringProp name="Argument.name">connectionString</stringProp>
+                                <stringProp name="Argument.value"></stringProp>
+                                <stringProp name="Argument.metadata">=</stringProp>
+                            </elementProp>
+                            <elementProp name="liveMetrics" elementType="Argument">
+                                <stringProp name="Argument.name">liveMetrics</stringProp>
+                                <stringProp name="Argument.value">true</stringProp>
+                                <stringProp name="Argument.metadata">=</stringProp>
+                            </elementProp>
+                            <elementProp name="samplersList" elementType="Argument">
+                                <stringProp name="Argument.name">samplersList</stringProp>
+                                <stringProp name="Argument.value"></stringProp>
+                                <stringProp name="Argument.metadata">=</stringProp>
+                            </elementProp>
+                            <elementProp name="useRegexForSamplerList" elementType="Argument">
+                                <stringProp name="Argument.name">useRegexForSamplerList</stringProp>
+                                <stringProp name="Argument.value">false</stringProp>
+                                <stringProp name="Argument.metadata">=</stringProp>
+                            </elementProp>
+                            <elementProp name="logResponseData" elementType="Argument">
+                                <stringProp name="Argument.name">logResponseData</stringProp>
+                                <stringProp name="Argument.value">OnFailure</stringProp>
+                                <stringProp name="Argument.metadata">=</stringProp>
+                            </elementProp>
+                            <elementProp name="logSampleData" elementType="Argument">
+                                <stringProp name="Argument.name">logSampleData</stringProp>
+                                <stringProp name="Argument.value">OnFailure</stringProp>
+                                <stringProp name="Argument.metadata">=</stringProp>
+                            </elementProp>
+                        </collectionProp>
+                    </elementProp>
+                    <stringProp name="classname">io.github.adrianmo.jmeter.backendlistener.azure.AzureBackendClient</stringProp>
+                </BackendListener>
+                <hashTree/>
+            </hashTree>
+        </hashTree>
+        <WorkBench guiclass="WorkBenchGui" testclass="WorkBench" testname="WorkBench" enabled="true">
+            <boolProp name="WorkBench.save">true</boolProp>
+        </WorkBench>
+        <hashTree/>
+    </hashTree>
+</jmeterTestPlan>


### PR DESCRIPTION
While checking for non-existent classes in test plan, we are only checking for guiclass and testclass attributes. But in the case of backend listeners, the implementation class is stored as a stringProp in the node, so plugin manager is missing out on adding the required jar for this class. This change checks the implementation class and adds it to the non existent class list so that plugin manager can download the required jar file.

Relevant issue: https://groups.google.com/u/3/g/jmeter-plugins/c/xZ9VGl-b9UU