### PR TITLE
Replace json-lib with Gson for repo parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,6 @@
             <version>2.17.0</version>
         </dependency>
         <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>1.11.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.github.weisj</groupId>
             <artifactId>darklaf-property-loader</artifactId>
             <version>2.3.0</version>
@@ -88,10 +83,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>net.sf.json-lib</groupId>
-            <artifactId>json-lib</artifactId>
-            <version>2.4</version>
-            <classifier>jdk15</classifier>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.14.0</version>
         </dependency>
 
         <dependency>
@@ -127,7 +121,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.1</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -137,12 +131,26 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    <include>net.sf.json-lib:json-lib</include>
-                                    <include>commons-lang:commons-lang</include>
-                                    <include>net.sf.ezmorph:ezmorph</include>
-                                    <include>commons-beanutils:commons-beanutils</include>
+                                    <include>com.google.code.gson:gson</include>
                                 </includes>
                             </artifactSet>
+                            <!-- we land in JMeter's lib/ext next to arbitrary other plugins,
+                                 so don't expose a bare com.google.gson that could clash -->
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.gson</pattern>
+                                    <shadedPattern>org.jmeterplugins.repository.shaded.gson</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <filters>
+                                <filter>
+                                    <artifact>com.google.code.gson:gson</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/versions/**</exclude>
+                                        <exclude>module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/org/jmeterplugins/repository/JARSource.java
+++ b/src/main/java/org/jmeterplugins/repository/JARSource.java
@@ -2,10 +2,10 @@ package org.jmeterplugins.repository;
 
 import java.io.IOException;
 
-import net.sf.json.JSON;
+import com.google.gson.JsonElement;
 
 abstract public class JARSource implements Cloneable {
-    public abstract JSON getRepo() throws IOException;
+    public abstract JsonElement getRepo() throws IOException;
 
     public abstract void reportStats(String[] usageStats) throws IOException;
 

--- a/src/main/java/org/jmeterplugins/repository/JARSourceFilesystem.java
+++ b/src/main/java/org/jmeterplugins/repository/JARSourceFilesystem.java
@@ -1,9 +1,8 @@
 package org.jmeterplugins.repository;
 
 
-import net.sf.json.JSON;
-import net.sf.json.JSONSerializer;
-import net.sf.json.JsonConfig;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,8 +21,8 @@ public class JARSourceFilesystem extends JARSource {
     }
 
     @Override
-    public JSON getRepo() throws IOException {
-        return JSONSerializer.toJSON(FileUtils.readFileToString(jsonFile), new JsonConfig());
+    public JsonElement getRepo() throws IOException {
+        return JsonParser.parseString(FileUtils.readFileToString(jsonFile));
     }
 
     @Override

--- a/src/main/java/org/jmeterplugins/repository/JARSourceHTTP.java
+++ b/src/main/java/org/jmeterplugins/repository/JARSourceHTTP.java
@@ -1,10 +1,8 @@
 package org.jmeterplugins.repository;
 
-import net.sf.json.JSON;
-import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
-import net.sf.json.JSONSerializer;
-import net.sf.json.JsonConfig;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.output.ByteArrayOutputStream;
@@ -140,7 +138,7 @@ public class JARSourceHTTP extends JARSource {
         return client;
     }
 
-    protected JSON getJSON(String uri) throws IOException {
+    protected JsonElement getJSON(String uri) throws IOException {
         log.info("Requesting " + uri);
 
         HttpRequestBase get = new HttpGet(uri);
@@ -169,7 +167,7 @@ public class JARSourceHTTP extends JARSource {
             }
 
             cacheRepo(response, result, uri);
-            return JSONSerializer.toJSON(response, new JsonConfig());
+            return JsonParser.parseString(response);
         } finally {
             get.abort();
             try {
@@ -265,29 +263,29 @@ public class JARSourceHTTP extends JARSource {
         return buffer.toString();
     }
 
-    protected JSONArray getRepositories(String path) throws IOException {
-        final List<JSON> repositories = new ArrayList<>(addresses.length);
+    protected JsonArray getRepositories(String path) throws IOException {
+        final List<JsonElement> repositories = new ArrayList<>(addresses.length);
         for (String address : addresses) {
             PluginsRepo repo = getRepoCache(address + path);
             if (repo != null && repo.isActual()) {
                 log.info("Found cached repo");
-                repositories.add(JSONSerializer.toJSON(repo.getRepoJSON(), new JsonConfig()));
+                repositories.add(JsonParser.parseString(repo.getRepoJSON()));
             } else {
                 repositories.add(getJSON(address + path));
             }
         }
 
-        final JSONArray result = new JSONArray();
+        final JsonArray result = new JsonArray();
         final List<String> pluginsIDs = new ArrayList<>();
 
-        for (JSON json : repositories) {
-            if (!(json instanceof JSONArray)) {
+        for (JsonElement json : repositories) {
+            if (json == null || !json.isJsonArray()) {
                 throw new RuntimeException("Result is not array");
             }
 
-            for (Object elm : (JSONArray) json) {
+            for (JsonElement elm : json.getAsJsonArray()) {
                 // resolve plugin-id conflicts
-                String id = ((JSONObject) elm).getString("id");
+                String id = elm.getAsJsonObject().get("id").getAsString();
                 if (!pluginsIDs.contains(id)) {
                     pluginsIDs.add(id);
                     result.add(elm);
@@ -300,7 +298,7 @@ public class JARSourceHTTP extends JARSource {
     }
 
     @Override
-    public JSON getRepo() throws IOException {
+    public JsonElement getRepo() throws IOException {
         return getRepositories("?installID=" + getInstallID());
     }
 

--- a/src/main/java/org/jmeterplugins/repository/Plugin.java
+++ b/src/main/java/org/jmeterplugins/repository/Plugin.java
@@ -1,9 +1,9 @@
 package org.jmeterplugins.repository;
 
 
-import net.sf.json.JSONArray;
-import net.sf.json.JSONNull;
-import net.sf.json.JSONObject;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import org.apache.jmeter.engine.JMeterEngine;
 import org.apache.jmeter.util.JMeterUtils;
 import org.slf4j.Logger;
@@ -27,7 +27,7 @@ public class Plugin {
     private static final Logger log = LoggerFactory.getLogger(Plugin.class);
     private static final Pattern dependsParser = Pattern.compile("([^=<>]+)([=<>]+[0-9.]+)?");
     public static final String VER_STOCK = "0.0.0-STOCK";
-    protected JSONObject versions = new JSONObject();
+    protected JsonObject versions = new JsonObject();
     protected String id;
     protected String markerClass;
     protected String installedPath;
@@ -49,40 +49,71 @@ public class Plugin {
         id = aId;
     }
 
-    public static Plugin fromJSON(JSONObject elm) {
-        Plugin inst = new Plugin(elm.getString("id"));
-        if (!(elm.get("markerClass") instanceof JSONNull)) {
-            inst.markerClass = elm.getString("markerClass");
+    public static Plugin fromJSON(JsonObject elm) {
+        Plugin inst = new Plugin(getString(elm, "id"));
+        if (!isNull(elm, "markerClass")) {
+            inst.markerClass = getString(elm, "markerClass");
         }
         inst.componentClasses = new ArrayList<>();
         if (inst.markerClass != null) {
             inst.componentClasses.add(inst.markerClass);
         }
-        if (elm.containsKey("componentClasses")) {
-            JSONArray componentsJSON = elm.getJSONArray("componentClasses");
-            if (componentsJSON.size() > 0) {
-                for (int i = 0; i < componentsJSON.size(); i++) {
-                    inst.componentClasses.add(componentsJSON.getString(i));
-                }
+        if (elm.has("componentClasses")) {
+            JsonArray componentsJSON = elm.getAsJsonArray("componentClasses");
+            for (JsonElement component : componentsJSON) {
+                inst.componentClasses.add(component.getAsString());
             }
         }
-        if (elm.get("versions") instanceof JSONObject) {
-            inst.versions = elm.getJSONObject("versions");
+        if (elm.has("versions") && elm.get("versions").isJsonObject()) {
+            inst.versions = elm.getAsJsonObject("versions");
         }
-        inst.name = elm.getString("name");
-        inst.description = elm.getString("description");
-        if (elm.containsKey("screenshotUrl")) {
-            inst.screenshot = elm.getString("screenshotUrl");
+        inst.name = getString(elm, "name");
+        inst.description = getString(elm, "description");
+        if (elm.has("screenshotUrl")) {
+            inst.screenshot = getString(elm, "screenshotUrl");
         }
-        inst.helpLink = elm.getString("helpUrl");
-        inst.vendor = elm.getString("vendor");
-        if (elm.containsKey("canUninstall")) {
-            inst.canUninstall = elm.getBoolean("canUninstall");
+        inst.helpLink = getString(elm, "helpUrl");
+        inst.vendor = getString(elm, "vendor");
+        if (elm.has("canUninstall")) {
+            inst.canUninstall = elm.get("canUninstall").getAsBoolean();
         }
-        if (elm.containsKey("installerClass")) {
-            inst.installerClass = elm.getString("installerClass");
+        if (elm.has("installerClass")) {
+            inst.installerClass = getString(elm, "installerClass");
         }
         return inst;
+    }
+
+    private static boolean isNull(JsonObject elm, String key) {
+        return elm.has(key) && elm.get(key).isJsonNull();
+    }
+
+    /**
+     * Reads a repo field as string, keeping the coercions the repo relies on: numbers and
+     * booleans stringify, and an explicit JSON null yields the literal "null" as json-lib did.
+     * A field that is absent altogether is a broken repo entry, so it fails loudly.
+     */
+    private static String getString(JsonObject elm, String key) {
+        JsonElement value = elm.get(key);
+        if (value == null) {
+            throw new IllegalArgumentException("Repository entry has no '" + key + "' field: " + elm);
+        }
+        return asString(value);
+    }
+
+    private static String asString(JsonElement value) {
+        return value.isJsonNull() ? "null" : value.getAsString();
+    }
+
+    /**
+     * A version whose body is absent or JSON null reads as an empty one, so callers see
+     * "no depends / no libs / no changes" instead of blowing up. That is what json-lib
+     * returned from getJSONObject() for such versions, and the repo does contain them.
+     *
+     * @return the body of given version, or an empty object when that version is absent or null
+     */
+    private JsonObject getVersionSpec(String verStr) {
+        JsonElement spec = (verStr == null) ? null : versions.get(verStr);
+        return (spec != null && spec.isJsonObject()) ? spec.getAsJsonObject() : new JsonObject();
     }
 
     @Override
@@ -145,7 +176,7 @@ public class Plugin {
     }
 
     public boolean isVersionFrozenToJMeter() {
-        return versions.containsKey("");
+        return versions.has("");
     }
 
     public String getMaxVersion() {
@@ -159,14 +190,11 @@ public class Plugin {
 
     public Set<String> getVersions() {
         Set<String> versions = new TreeSet<>(new VersionComparator());
-        for (Object o : this.versions.keySet()) {
-            if (o instanceof String) {
-                String ver = (String) o;
-                if (ver.isEmpty()) {
-                    versions.add(getJMeterVersion());
-                } else {
-                    versions.add(ver);
-                }
+        for (String ver : this.versions.keySet()) {
+            if (ver.isEmpty()) {
+                versions.add(getJMeterVersion());
+            } else {
+                versions.add(ver);
             }
         }
 
@@ -279,15 +307,22 @@ public class Plugin {
     public String getDownloadUrl(String version) {
         String location;
         if (isVersionFrozenToJMeter()) {
-            String downloadUrl = versions.getJSONObject("").getString("downloadUrl");
-            location = String.format(downloadUrl, getJMeterVersion());
+            location = String.format(readDownloadUrl(""), getJMeterVersion());
         } else {
-            if (!versions.containsKey(version)) {
+            if (!versions.has(version)) {
                 throw new IllegalArgumentException("Version " + version + " not found for plugin " + this);
             }
-            location = versions.getJSONObject(version).getString("downloadUrl");
+            location = readDownloadUrl(version);
         }
         return location;
+    }
+
+    private String readDownloadUrl(String verStr) {
+        JsonElement url = getVersionSpec(verStr).get("downloadUrl");
+        if (url == null) {
+            throw new IllegalArgumentException("Version " + verStr + " of plugin " + this + " has no downloadUrl");
+        }
+        return asString(url);
     }
 
     public String getName() {
@@ -337,18 +372,16 @@ public class Plugin {
 
     public Set<String> getDepends() {
         Set<String> depends = new HashSet<>();
-        JSONObject version = versions.getJSONObject(getCandidateVersion());
-        if (version.containsKey("depends")) {
-            JSONArray list = version.getJSONArray("depends");
-            for (Object o : list) {
-                if (o instanceof String) {
-                    String dep = (String) o;
-                    Matcher m = dependsParser.matcher(dep);
-                    if (!m.find()) {
-                        throw new IllegalArgumentException("Cannot parse depend str: " + dep);
-                    }
-                    depends.add(m.group(1));
+        JsonObject version = getVersionSpec(getCandidateVersion());
+        if (version.has("depends")) {
+            JsonArray list = version.getAsJsonArray("depends");
+            for (JsonElement o : list) {
+                String dep = asString(o);
+                Matcher m = dependsParser.matcher(dep);
+                if (!m.find()) {
+                    throw new IllegalArgumentException("Cannot parse depend str: " + dep);
                 }
+                depends.add(m.group(1));
             }
         }
         return depends;
@@ -356,14 +389,10 @@ public class Plugin {
 
     public Map<String, String> getLibs(String verStr) {
         Map<String, String> depends = new HashMap<>();
-        JSONObject version = versions.getJSONObject(isVersionFrozenToJMeter() ? "" : verStr);
-        if (version.containsKey("libs")) {
-            JSONObject list = version.getJSONObject("libs");
-            for (Object o : list.keySet()) {
-                if (o instanceof String) {
-                    String dep = (String) o;
-                    depends.put(dep, list.getString(dep));
-                }
+        JsonObject version = getVersionSpec(isVersionFrozenToJMeter() ? "" : verStr);
+        if (version.has("libs")) {
+            for (Map.Entry<String, JsonElement> lib : version.getAsJsonObject("libs").entrySet()) {
+                depends.put(lib.getKey(), asString(lib.getValue()));
             }
         }
         return depends;
@@ -381,9 +410,9 @@ public class Plugin {
     }
 
     public String getVersionChanges(String versionStr) {
-        JSONObject version = versions.getJSONObject(versionStr);
-        return version.containsKey("changes") ?
-                version.getString("changes") :
+        JsonObject version = getVersionSpec(versionStr);
+        return version.has("changes") ?
+                asString(version.get("changes")) :
                 null;
     }
 

--- a/src/main/java/org/jmeterplugins/repository/PluginManager.java
+++ b/src/main/java/org/jmeterplugins/repository/PluginManager.java
@@ -1,10 +1,8 @@
 package org.jmeterplugins.repository;
 
 
-import net.sf.json.JSON;
-import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
-import net.sf.json.JSONSerializer;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import org.apache.jmeter.assertions.Assertion;
 import org.apache.jmeter.config.ConfigElement;
 import org.apache.jmeter.control.Controller;
@@ -68,15 +66,15 @@ public class PluginManager {
             return;
         }
 
-        JSON json = jarSource.getRepo();
+        JsonElement json = jarSource.getRepo();
 
-        if (!(json instanceof JSONArray)) {
+        if (json == null || !json.isJsonArray()) {
             throw new RuntimeException("Result is not array");
         }
 
-        for (Object elm : (JSONArray) json) {
-            if (elm instanceof JSONObject) {
-                Plugin plugin = Plugin.fromJSON((JSONObject) elm);
+        for (JsonElement elm : json.getAsJsonArray()) {
+            if (elm.isJsonObject()) {
+                Plugin plugin = Plugin.fromJSON(elm.getAsJsonObject());
                 if (plugin.getName().isEmpty()) {
                     log.debug("Skip empty name: " + plugin);
                     continue;
@@ -467,7 +465,7 @@ public class PluginManager {
                 };
                 String[] searchPaths = {plugin.installedPath};
                 List<String> list = ClassFinder.findClassesThatExtend(searchPaths, superClasses);
-                report.append(plugin.id).append("\n").append("\"componentClasses\":").append(JSONSerializer.toJSON(list.toArray()).toString()).append(",\n");
+                report.append(plugin.id).append("\n").append("\"componentClasses\":").append(new Gson().toJson(list)).append(",\n");
             } catch (Throwable e) {
                 log.error("Failed to get classes", e);
             }

--- a/src/test/java/org/jmeterplugins/repository/DependencyResolverTest.java
+++ b/src/test/java/org/jmeterplugins/repository/DependencyResolverTest.java
@@ -1,9 +1,8 @@
 package org.jmeterplugins.repository;
 
-import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
-import net.sf.json.JSONSerializer;
-import net.sf.json.JsonConfig;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
@@ -105,7 +104,7 @@ public class DependencyResolverTest {
         Map<Plugin, Boolean> plugs = new HashMap<>();
 
         PluginMock cause = new PluginMock("cause", Plugin.getJMeterVersion());
-        cause.setVersions(JSONObject.fromObject("{\"\":null}", new JsonConfig()));
+        cause.setVersions(JsonParser.parseString("{\"\":null}").getAsJsonObject());
         plugs.put(cause, true);
 
         PluginMock effect = new PluginMock("effect", null);
@@ -180,11 +179,11 @@ public class DependencyResolverTest {
     @Test
     public void testLibVersionManagement() throws Exception {
         URL url = PluginManagerTest.class.getResource("/lib_versions.json");
-        JSONArray jsonArray = (JSONArray) JSONSerializer.toJSON(FileUtils.readFileToString(new File(url.getPath())), new JsonConfig());
+        JsonArray jsonArray = JsonParser.parseString(FileUtils.readFileToString(new File(url.getPath()))).getAsJsonArray();
 
         Map<Plugin, Boolean> map = new HashMap<>();
-        for (Object obj : jsonArray) {
-            Plugin plugin = Plugin.fromJSON((JSONObject) obj);
+        for (JsonElement obj : jsonArray) {
+            Plugin plugin = Plugin.fromJSON(obj.getAsJsonObject());
             plugin.detectInstalled(new HashSet<Plugin>());
             map.put(plugin, true);
         }
@@ -217,11 +216,11 @@ public class DependencyResolverTest {
     @Test
     public void testResolveLibBeforeDetete() throws Exception {
         URL url = PluginManagerTest.class.getResource("/lib_for_delete");
-        JSONArray jsonArray = (JSONArray) JSONSerializer.toJSON(FileUtils.readFileToString(new File(url.getPath())), new JsonConfig());
+        JsonArray jsonArray = JsonParser.parseString(FileUtils.readFileToString(new File(url.getPath()))).getAsJsonArray();
 
         Map<Plugin, Boolean> map = new HashMap<>();
-        for (Object obj : jsonArray) {
-            Plugin plugin = Plugin.fromJSON((JSONObject) obj);
+        for (JsonElement obj : jsonArray) {
+            Plugin plugin = Plugin.fromJSON(obj.getAsJsonObject());
             plugin.detectInstalled(new HashSet<Plugin>());
             plugin.installedPath = "";
             plugin.installedVersion = "0.1";
@@ -243,11 +242,11 @@ public class DependencyResolverTest {
     @Test
     public void testResolveDowngradeWithNPE() throws Exception {
         URL url = PluginManagerTest.class.getResource("/self_npe.json");
-        JSONArray jsonArray = (JSONArray) JSONSerializer.toJSON(FileUtils.readFileToString(new File(url.getPath())), new JsonConfig());
+        JsonArray jsonArray = JsonParser.parseString(FileUtils.readFileToString(new File(url.getPath()))).getAsJsonArray();
 
         Map<Plugin, Boolean> map = new HashMap<>();
-        for (Object obj : jsonArray) {
-            Plugin plugin = Plugin.fromJSON((JSONObject) obj);
+        for (JsonElement obj : jsonArray) {
+            Plugin plugin = Plugin.fromJSON(obj.getAsJsonObject());
             plugin.detectInstalled(new HashSet<Plugin>());
             plugin.installedPath = "";
             plugin.installedVersion = "0.14";
@@ -275,11 +274,11 @@ public class DependencyResolverTest {
     @Test
     public void testResolveMissingLib() throws Exception {
         URL url = PluginManagerTest.class.getResource("/self_npe.json");
-        JSONArray jsonArray = (JSONArray) JSONSerializer.toJSON(FileUtils.readFileToString(new File(url.getPath())), new JsonConfig());
+        JsonArray jsonArray = JsonParser.parseString(FileUtils.readFileToString(new File(url.getPath()))).getAsJsonArray();
 
         Map<Plugin, Boolean> map = new HashMap<>();
-        for (Object obj : jsonArray) {
-            Plugin plugin = Plugin.fromJSON((JSONObject) obj);
+        for (JsonElement obj : jsonArray) {
+            Plugin plugin = Plugin.fromJSON(obj.getAsJsonObject());
             plugin.detectInstalled(new HashSet<Plugin>());
             plugin.installedPath = "";
             plugin.installedVersion = "0.14";
@@ -306,11 +305,11 @@ public class DependencyResolverTest {
     @Test
     public void testResolveLibIfLibBroken() throws Exception {
         URL url = PluginManagerTest.class.getResource("/broken.json");
-        JSONArray jsonArray = (JSONArray) JSONSerializer.toJSON(FileUtils.readFileToString(new File(url.getPath())), new JsonConfig());
+        JsonArray jsonArray = JsonParser.parseString(FileUtils.readFileToString(new File(url.getPath()))).getAsJsonArray();
 
         Map<Plugin, Boolean> map = new HashMap<>();
-        for (Object obj : jsonArray) {
-            Plugin plugin = Plugin.fromJSON((JSONObject) obj);
+        for (JsonElement obj : jsonArray) {
+            Plugin plugin = Plugin.fromJSON(obj.getAsJsonObject());
             plugin.detectInstalled(new HashSet<Plugin>());
             plugin.installedPath = "";
             plugin.installedVersion = "0.1";
@@ -334,11 +333,11 @@ public class DependencyResolverTest {
     @Test
     public void testUpdateLibWithPlugin() throws Exception {
         URL url = PluginManagerTest.class.getResource("/lib_update.json");
-        JSONArray jsonArray = (JSONArray) JSONSerializer.toJSON(FileUtils.readFileToString(new File(url.getPath())), new JsonConfig());
+        JsonArray jsonArray = JsonParser.parseString(FileUtils.readFileToString(new File(url.getPath()))).getAsJsonArray();
 
         Map<Plugin, Boolean> map = new HashMap<>();
-        for (Object obj : jsonArray) {
-            Plugin plugin = Plugin.fromJSON((JSONObject) obj);
+        for (JsonElement obj : jsonArray) {
+            Plugin plugin = Plugin.fromJSON(obj.getAsJsonObject());
             plugin.detectInstalled(new HashSet<Plugin>());
             plugin.installedPath = "";
             plugin.installedVersion = "0.1";
@@ -364,11 +363,11 @@ public class DependencyResolverTest {
     @Test
     public void testUpdateWhenInstall() throws Exception {
         URL url = PluginManagerTest.class.getResource("/installed.json");
-        JSONArray jsonArray = (JSONArray) JSONSerializer.toJSON(FileUtils.readFileToString(new File(url.getPath())), new JsonConfig());
+        JsonArray jsonArray = JsonParser.parseString(FileUtils.readFileToString(new File(url.getPath()))).getAsJsonArray();
 
         Map<Plugin, Boolean> map = new HashMap<>();
-        for (Object obj : jsonArray) {
-            Plugin plugin = Plugin.fromJSON((JSONObject) obj);
+        for (JsonElement obj : jsonArray) {
+            Plugin plugin = Plugin.fromJSON(obj.getAsJsonObject());
             plugin.detectInstalled(new HashSet<Plugin>());
 
             map.put(plugin, true);
@@ -390,11 +389,11 @@ public class DependencyResolverTest {
     @Test
     public void testInstallNewLibWithMinVersion() throws Exception {
         URL url = PluginManagerTest.class.getResource("/installed2.json");
-        JSONArray jsonArray = (JSONArray) JSONSerializer.toJSON(FileUtils.readFileToString(new File(url.getPath())), new JsonConfig());
+        JsonArray jsonArray = JsonParser.parseString(FileUtils.readFileToString(new File(url.getPath()))).getAsJsonArray();
 
         Map<Plugin, Boolean> map = new HashMap<>();
-        for (Object obj : jsonArray) {
-            Plugin plugin = Plugin.fromJSON((JSONObject) obj);
+        for (JsonElement obj : jsonArray) {
+            Plugin plugin = Plugin.fromJSON(obj.getAsJsonObject());
             plugin.detectInstalled(new HashSet<Plugin>());
 
             map.put(plugin, Boolean.TRUE);
@@ -459,11 +458,11 @@ public class DependencyResolverTest {
     @Test
     public void testLibsWithSymbolNames() throws Exception {
         URL url = PluginManagerTest.class.getResource("/http2_libs.json");
-        JSONArray jsonArray = (JSONArray) JSONSerializer.toJSON(FileUtils.readFileToString(new File(url.getPath())), new JsonConfig());
+        JsonArray jsonArray = JsonParser.parseString(FileUtils.readFileToString(new File(url.getPath()))).getAsJsonArray();
 
         Map<Plugin, Boolean> map = new HashMap<>();
-        for (Object obj : jsonArray) {
-            Plugin plugin = Plugin.fromJSON((JSONObject) obj);
+        for (JsonElement obj : jsonArray) {
+            Plugin plugin = Plugin.fromJSON(obj.getAsJsonObject());
             plugin.detectInstalled(new HashSet<Plugin>());
             map.put(plugin, true);
         }

--- a/src/test/java/org/jmeterplugins/repository/JARSourceEmul.java
+++ b/src/test/java/org/jmeterplugins/repository/JARSourceEmul.java
@@ -1,12 +1,12 @@
 package org.jmeterplugins.repository;
 
-import net.sf.json.JSON;
+import com.google.gson.JsonElement;
 
 import java.io.IOException;
 
 public class JARSourceEmul extends JARSource {
     @Override
-    public JSON getRepo() throws IOException {
+    public JsonElement getRepo() throws IOException {
         return null;
     }
 

--- a/src/test/java/org/jmeterplugins/repository/PluginManagerDialogTest.java
+++ b/src/test/java/org/jmeterplugins/repository/PluginManagerDialogTest.java
@@ -1,8 +1,8 @@
 package org.jmeterplugins.repository;
 
 import kg.apc.emulators.TestJMeterUtils;
-import net.sf.json.JSONObject;
-import net.sf.json.JsonConfig;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.apache.jmeter.util.JMeterUtils;
 import org.jmeterplugins.repository.exception.DownloadException;
 import org.junit.BeforeClass;

--- a/src/test/java/org/jmeterplugins/repository/PluginManagerTest.java
+++ b/src/test/java/org/jmeterplugins/repository/PluginManagerTest.java
@@ -1,8 +1,8 @@
 package org.jmeterplugins.repository;
 
 import kg.apc.emulators.TestJMeterUtils;
-import net.sf.json.JSONObject;
-import net.sf.json.JsonConfig;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.apache.jmeter.engine.JMeterEngine;
 import org.apache.jmeter.util.JMeterUtils;
 import org.jmeterplugins.repository.exception.DownloadException;
@@ -111,7 +111,7 @@ public class PluginManagerTest {
         try {
             JMeterUtils.setProperty("jpgc.repo.address", "http://httpstat.us/500");
 
-            Plugin p = Plugin.fromJSON(JSONObject.fromObject(str, new JsonConfig()));
+            Plugin p = Plugin.fromJSON(JsonParser.parseString(str).getAsJsonObject());
             PluginManager manager = new PluginManager();
             manager.allPlugins.put(p, true); // need to install
             p.setCandidateVersion("9999");

--- a/src/test/java/org/jmeterplugins/repository/PluginMock.java
+++ b/src/test/java/org/jmeterplugins/repository/PluginMock.java
@@ -1,7 +1,7 @@
 package org.jmeterplugins.repository;
 
-import net.sf.json.JSONObject;
-import net.sf.json.JsonConfig;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -17,7 +17,7 @@ public class PluginMock extends Plugin {
         super(id);
         installedVersion = iVer;
         installedPath = iVer;
-        versions = JSONObject.fromObject("{\"1.0\":null,\"0.1\":null,\"0.1.5\":null}", new JsonConfig());
+        versions = JsonParser.parseString("{\"1.0\":null,\"0.1\":null,\"0.1.5\":null}").getAsJsonObject();
         candidateVersion = getMaxVersion();
     }
 
@@ -47,7 +47,7 @@ public class PluginMock extends Plugin {
         this.libs = libs;
     }
 
-    public void setVersions(JSONObject a) {
+    public void setVersions(JsonObject a) {
         versions = a;
     }
 

--- a/src/test/java/org/jmeterplugins/repository/PluginTest.java
+++ b/src/test/java/org/jmeterplugins/repository/PluginTest.java
@@ -1,7 +1,7 @@
 package org.jmeterplugins.repository;
 
-import net.sf.json.JSONObject;
-import net.sf.json.JsonConfig;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.apache.jmeter.engine.JMeterEngine;
 import org.junit.Test;
 
@@ -38,7 +38,7 @@ public class PluginTest {
     public void testVirtual() throws Exception {
         PluginMock obj = new PluginMock("virtual");
         obj.setCandidateVersion("0");
-        obj.setVersions(JSONObject.fromObject("{\"0\": {\"downloadUrl\": null}}", new JsonConfig()));
+        obj.setVersions(JsonParser.parseString("{\"0\": {\"downloadUrl\": null}}").getAsJsonObject());
         assertTrue(obj.isVirtual());
         HashSet<String> depends = new HashSet<>();
         depends.add("mock");
@@ -62,7 +62,7 @@ public class PluginTest {
     @Test
     public void testInstallerClass() {
         String str = "{\"id\": 0, \"markerClass\": 0, \"name\": 0, \"description\": 0, \"helpUrl\": 0, \"vendor\": 0, \"installerClass\": \"test\"}";
-        Plugin p = Plugin.fromJSON(JSONObject.fromObject(str, new JsonConfig()));
+        Plugin p = Plugin.fromJSON(JsonParser.parseString(str).getAsJsonObject());
         assertEquals("test", p.getInstallerClass());
     }
 
@@ -70,12 +70,12 @@ public class PluginTest {
     public void testVersionChanges() {
         String str = "{\"id\": 0,  \"markerClass\": 0, \"name\": 0, \"description\": 0, \"helpUrl\": 0, \"vendor\": 0, \"installerClass\": \"test\", " +
                 "\"versions\" : { \"0.1\" : { \"changes\": \"fix verified exception\" } }}";
-        Plugin p = Plugin.fromJSON(JSONObject.fromObject(str, new JsonConfig()));
+        Plugin p = Plugin.fromJSON(JsonParser.parseString(str).getAsJsonObject());
         assertEquals("fix verified exception", p.getVersionChanges("0.1"));
 
         str = "{\"id\": 0,  \"markerClass\": 0, \"name\": 0, \"description\": 0, \"helpUrl\": 0, \"vendor\": 0, \"installerClass\": \"test\", " +
                 "\"versions\" : { \"0.1\" : {  } }}";
-        p = Plugin.fromJSON(JSONObject.fromObject(str, new JsonConfig()));
+        p = Plugin.fromJSON(JsonParser.parseString(str).getAsJsonObject());
         assertNull(p.getVersionChanges("0.1"));
     }
 
@@ -83,7 +83,7 @@ public class PluginTest {
     public void testAllData() {
         String str = "{\"id\": \"id\", \"markerClass\": \"class\", \"name\": \"name\", \"description\": \"description\"," +
                 " \"helpUrl\": 0, \"vendor\": 0, \"installerClass\": \"test\"}";
-        Plugin p = Plugin.fromJSON(JSONObject.fromObject(str, new JsonConfig()));
+        Plugin p = Plugin.fromJSON(JsonParser.parseString(str).getAsJsonObject());
         assertEquals("idnamedescriptionclass", p.getSearchIndexString());
     }
 }

--- a/src/test/java/org/jmeterplugins/repository/PluginsListTest.java
+++ b/src/test/java/org/jmeterplugins/repository/PluginsListTest.java
@@ -18,8 +18,8 @@ import javax.swing.event.ListSelectionEvent;
 
 import org.junit.Test;
 
-import net.sf.json.JSONObject;
-import net.sf.json.JsonConfig;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 public class PluginsListTest {
 
@@ -36,7 +36,7 @@ public class PluginsListTest {
                 "\"0.2\" : { \"changes\": \"fix verified exception1\", \"downloadUrl\": \"https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-webdriver/0.3/jmeter-plugins-webdriver-0.2.jar\"}," +
                 "\"0.3\" : { \"changes\": \"fix verified exception1\", " +
                 "\"downloadUrl\": \"https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-webdriver/0.3/jmeter-plugins-webdriver-0.3.jar\"} }}";
-        Plugin p = Plugin.fromJSON(JSONObject.fromObject(str, new JsonConfig()));
+        Plugin p = Plugin.fromJSON(JsonParser.parseString(str).getAsJsonObject());
 
         Set<Plugin> set = new HashSet<>();
         set.add(p);

--- a/src/test/java/org/jmeterplugins/repository/RepoTest.java
+++ b/src/test/java/org/jmeterplugins/repository/RepoTest.java
@@ -10,12 +10,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 import junit.framework.AssertionFailedError;
-import net.sf.json.JSON;
-import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
-import net.sf.json.JSONSerializer;
-import net.sf.json.JsonConfig;
 
 import org.apache.commons.io.FileUtils;
 
@@ -49,14 +50,13 @@ public class RepoTest {
         List<String> problems = new ArrayList<>();
         File[] files = getRepoFiles();
 
-        JSONArray merged = new JSONArray();
+        JsonArray merged = new JsonArray();
         for (File repoFile : files) {
             System.out.println("Checking repo: " + repoFile.getCanonicalPath());
             String content = new String(Files.readAllBytes(Paths.get(repoFile.getAbsolutePath())), "UTF-8");
-            JSON json = JSONSerializer.toJSON(content, new JsonConfig());
-            JSONArray list = (JSONArray) json;
-            for (Object item : list) {
-                JSONObject spec = (JSONObject) item;
+            JsonArray list = JsonParser.parseString(content).getAsJsonArray();
+            for (JsonElement item : list) {
+                JsonObject spec = item.getAsJsonObject();
                 checkPlugin(problems, repoFile, spec);
                 merged.add(spec);
             }
@@ -67,7 +67,7 @@ public class RepoTest {
         }
 
         try (PrintWriter out = new PrintWriter(new File(repo.getAbsolutePath() + s + "all.json"));) {
-            out.print(merged.toString(1));
+            out.print(new GsonBuilder().setPrettyPrinting().create().toJson(merged));
         }
     }
 
@@ -83,17 +83,17 @@ public class RepoTest {
         return files;
     }
 
-    private void checkPlugin(List<String> problems, File repoFile, JSONObject spec) {
+    private void checkPlugin(List<String> problems, File repoFile, JsonObject spec) {
         Plugin plugin = Plugin.fromJSON(spec);
         if (plugin.isVirtual()) {
             return;
         }
 
         String maxVersion = plugin.getMaxVersion();
-        JSONObject maxVerObject = spec.getJSONObject("versions").getJSONObject(maxVersion);
+        JsonObject maxVerObject = spec.getAsJsonObject("versions").getAsJsonObject(maxVersion);
 
-        JSONObject newVersions = new JSONObject();
-        newVersions.put(maxVersion, maxVerObject);
+        JsonObject newVersions = new JsonObject();
+        newVersions.add(maxVersion, maxVerObject);
 
         try {
             System.out.println("Checking plugin: " + plugin);
@@ -106,7 +106,7 @@ public class RepoTest {
                 File to = new File(libExt.getAbsolutePath() + File.separator + dest.getName());
                 jar.renameTo(to);
 
-                maxVerObject.put("downloadUrl", "lib/ext/" + dest.getName());
+                maxVerObject.addProperty("downloadUrl", "lib/ext/" + dest.getName());
             }
         } catch (Throwable e) {
             problems.add(repoFile.getName() + ":" + plugin);
@@ -116,13 +116,13 @@ public class RepoTest {
 
         checkLibs(problems, repoFile, plugin, maxVerObject);
 
-        if (!maxVerObject.isEmpty()) {
-            newVersions.put(maxVersion, maxVerObject);
-            spec.put("versions", newVersions);
+        if (maxVerObject.size() > 0) {
+            newVersions.add(maxVersion, maxVerObject);
+            spec.add("versions", newVersions);
         }
     }
 
-    private void checkLibs(List<String> problems, File repoFile, Plugin plugin, JSONObject maxVerObject) {
+    private void checkLibs(List<String> problems, File repoFile, Plugin plugin, JsonObject maxVerObject) {
         Map<String, String> libs = plugin.getLibs(plugin.getCandidateVersion());
         for (String id : libs.keySet()) {
             if (!cache.containsKey(libs.get(id))) {
@@ -141,7 +141,7 @@ public class RepoTest {
                 }
             }
 
-            maxVerObject.getJSONObject("libs").put(id, "lib/" + cache.get(libs.get(id)));
+            maxVerObject.getAsJsonObject("libs").addProperty(id, "lib/" + cache.get(libs.get(id)));
         }
     }
 


### PR DESCRIPTION
First of three PRs against plugin load time. Parser only — no protocol or repo-format change.

## Why

`json-lib` 2.4 is from 2010, unmaintained, and parses the production repo index at about 1.7 MB/s. That index is now ~471 KB (145 plugins, 575 versions), so the parse alone dominates load — including when served from the local disk cache, which stores the raw JSON string and re-parses it every time.

## Measured

Live `jmeter-plugins.org` repo snapshot, same JVM and classpath, `PluginManager.load()` against a local copy of the index:

| | first load | warm |
|---|---|---|
| before (json-lib) | 284 ms | 86–154 ms |
| after (Gson) | 68 ms | 15–29 ms |

Shipped jar: **909,776 → 468,310 bytes**. `json-lib` dragged in `commons-lang` 2.x, `ezmorph` and `commons-beanutils` — all shaded in, none used directly by this code. That also retires the recurring dependabot bumps against `commons-beanutils`, which was declared purely to pin json-lib's transitive dep.

Gson was chosen over Jackson: identical parse speed on this payload (33 ms cold / 4–6 ms warm for both), but one 313 KB jar with zero transitive deps versus Jackson's three jars totalling 2.3 MB. Jackson would have grown the artifact by ~1.5 MB. Relying on JMeter's own bundled Jackson was rejected — JMeter before 5.0 does not ship it.

## Correctness

A dump of every field of all 145 plugins and all 575 versions — name, vendor, depends, libs, requiredLibs, changes, downloadUrl, including the exception text for versions with no body — is **byte-identical** before and after.

json-lib's coercions are preserved deliberately, because the repo relies on them:
- numbers and booleans stringify (`"markerClass": 0` → `"0"`)
- an explicit JSON `null` reads as the literal string `"null"`
- a version whose body is absent or `null` reads as empty rather than throwing

That last one is why `getVersionSpec()` exists. It is ugly, and worth revisiting separately — but not in a PR whose job is to swap a parser.

## Build

`maven-shade-plugin` had to move 2.1 (2013) → 3.6.0; its bundled ASM cannot process modern class files and fails the build outright. Gson is relocated to `org.jmeterplugins.repository.shaded.gson`: we land in JMeter's `lib/ext` next to arbitrary other plugins, and this tool warns about JAR conflicts, so it should not create one by exposing a bare `com.google.gson`. Verified the shaded jar contains no unrelocated `com.google.gson`, no `module-info.class`, and no `META-INF/versions`.

## Tests

Same 72 tests, same 5 pre-existing failures before and after (all environment-dependent: network flake, JDK module access under xstream, and a path assertion). No new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)