### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,76 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: JDK ${{ matrix.java }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '8', '11', '17', '21' ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: maven
+
+      # runs the tests and builds the shaded package in one go
+      - name: Build
+        run: mvn -B --no-transfer-progress verify
+
+      - name: Check shaded jar
+        run: |
+          jar=$(ls target/jmeter-plugins-manager-*.jar | grep -v -E 'original|sources|javadoc' | head -1)
+          echo "Shaded artifact: $jar ($(stat -c%s "$jar") bytes)"
+          # gson must be present but only under its relocated name, so we never
+          # clash with whatever else lives in JMeter's lib/ext
+          unzip -l "$jar" | grep -q 'org/jmeterplugins/repository/shaded/gson/' \
+            || { echo "::error::relocated gson missing from shaded jar"; exit 1; }
+          if unzip -l "$jar" | grep -q ' com/google/gson/'; then
+            echo "::error::unrelocated com.google.gson leaked into shaded jar"; exit 1
+          fi
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports-jdk${{ matrix.java }}
+          path: target/surefire-reports/
+          if-no-files-found: ignore
+
+      - name: Coverage summary
+        if: always() && matrix.java == '17'
+        run: |
+          csv=target/site/jacoco/jacoco.csv
+          if [ ! -f "$csv" ]; then
+            echo "No coverage report produced." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          awk 'BEGIN { FS = "," }
+            FNR > 1 { im += $4; ic += $5; bm += $6; bc += $7; lm += $8; lc += $9 }
+            END {
+              printf "## Coverage\n\n";
+              printf "| metric | covered | missed | %% |\n|---|---:|---:|---:|\n";
+              printf "| instructions | %d | %d | %.1f%% |\n", ic, im, 100*ic/(ic+im);
+              printf "| branches | %d | %d | %.1f%% |\n", bc, bm, (bc+bm) ? 100*bc/(bc+bm) : 0;
+              printf "| lines | %d | %d | %.1f%% |\n", lc, lm, 100*lc/(lc+lm);
+            }' "$csv" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage report
+        if: always() && matrix.java == '17'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: target/site/jacoco/
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A prerequisite is to install `cmdrunner`:
 ```
-cd ${JMETER_HOME}/lib && wget https://repo1.maven.org/maven2/kg/apc/cmdrunner/2.2.1/cmdrunner-2.2.1.jar
+cd ${JMETER_HOME}/lib && wget https://repo1.maven.org/maven2/kg/apc/cmdrunner/2.3/cmdrunner-2.3.jar
 ```
 
 ### Option 1 - manual, get the latest version

--- a/pom.xml
+++ b/pom.xml
@@ -48,17 +48,17 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.25.5</version>
+            <version>2.26.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.4</version>
+            <version>2.26.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.0</version>
+            <version>2.26.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.weisj</groupId>
@@ -126,7 +126,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -163,7 +163,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.15</version>
                 <executions>
                     <execution>
                         <goals>
@@ -182,7 +182,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
+                <version>0.11.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.0</version>
                 <executions>
@@ -186,4 +191,32 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- JMeter's own launcher opens these for Java 9+, and the JMeter 2.13-era xstream
+             we compile against needs them to initialise SaveService under the module system -->
+        <profile>
+            <id>jdk9-opens</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>@{argLine}
+                                --add-opens java.base/java.lang=ALL-UNNAMED
+                                --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+                                --add-opens java.base/java.text=ALL-UNNAMED
+                                --add-opens java.base/java.util=ALL-UNNAMED
+                                --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+                                --add-opens java.desktop/java.awt.font=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,25 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
                 <version>0.7.0</version>

--- a/src/test/java/org/jmeterplugins/repository/ChangesMakerTest.java
+++ b/src/test/java/org/jmeterplugins/repository/ChangesMakerTest.java
@@ -10,6 +10,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertTrue;
 
@@ -64,14 +65,16 @@ public class ChangesMakerTest {
         assertTrue(res.length() > 0);
 
         String installFirst = "some_path_to_jar1" + File.pathSeparator + "plugin1\ttest1";
-        String installSecond = "jmeter-plugins-emulators-0.2.jar" + File.pathSeparator + "plugin2\ttest2";
+        // the emulators lib is resolved off the classpath, so don't pin its version here
+        Pattern installSecond = Pattern.compile("jmeter-plugins-emulators-[\\w.\\-]+\\.jar"
+                + Pattern.quote(File.pathSeparator) + "plugin2\ttest2");
 
         List<String> lines = Files.readAllLines(Paths.get(res.toURI()), Charset.defaultCharset());
         String fileContent = Arrays.toString(lines.toArray());
         System.out.println(fileContent);
 
         assertTrue(fileContent, fileContent.contains(installFirst));
-        assertTrue(fileContent, fileContent.contains(installSecond));
+        assertTrue(fileContent, installSecond.matcher(fileContent).find());
 
         File res2 = obj.getMovementsFile(plugins, plugins, new HashSet<Library.InstallationInfo>(), new HashSet<String>());
         assertTrue(res2.length() > 0);

--- a/src/test/java/org/jmeterplugins/repository/JMeterTestEnv.java
+++ b/src/test/java/org/jmeterplugins/repository/JMeterTestEnv.java
@@ -1,0 +1,26 @@
+package org.jmeterplugins.repository;
+
+import kg.apc.emulators.TestJMeterUtils;
+import org.apache.jmeter.util.JMeterUtils;
+
+/**
+ * Sets up the JMeter environment tests run in.
+ * <p>
+ * jmeter-plugins-emulators extracts its saveservice properties to &lt;home&gt;/ss.props but points
+ * the <code>saveservice_properties</code> property at that <em>absolute</em> path, while JMeter
+ * resolves the property against JMeter home - so SaveService looks for &lt;home&gt;&lt;home&gt;/ss.props,
+ * fails to initialise, and every lookup made through it afterwards reports "class not found".
+ * Re-point the property relative to home so SaveService can start.
+ */
+public class JMeterTestEnv {
+
+    public static void createJMeterEnv() {
+        TestJMeterUtils.createJmeterEnv();
+
+        String home = JMeterUtils.getJMeterHome();
+        String saveService = JMeterUtils.getPropDefault("saveservice_properties", "");
+        if (saveService.startsWith(home)) {
+            JMeterUtils.setProperty("saveservice_properties", saveService.substring(home.length()));
+        }
+    }
+}

--- a/src/test/java/org/jmeterplugins/repository/PluginManagerCMDTest.java
+++ b/src/test/java/org/jmeterplugins/repository/PluginManagerCMDTest.java
@@ -1,6 +1,5 @@
 package org.jmeterplugins.repository;
 
-import kg.apc.emulators.TestJMeterUtils;
 import org.apache.jmeter.util.JMeterUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -15,7 +14,7 @@ import static junit.framework.TestCase.fail;
 public class PluginManagerCMDTest {
     @BeforeClass
     public static void setup() {
-        TestJMeterUtils.createJmeterEnv();
+        JMeterTestEnv.createJMeterEnv();
         URL url = PluginManagerTest.class.getResource("/testVirtualPlugin.json");
         JMeterUtils.setProperty("jpgc.repo.address", url.getFile());
     }

--- a/src/test/java/org/jmeterplugins/repository/PluginManagerDialogTest.java
+++ b/src/test/java/org/jmeterplugins/repository/PluginManagerDialogTest.java
@@ -1,6 +1,5 @@
 package org.jmeterplugins.repository;
 
-import kg.apc.emulators.TestJMeterUtils;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.jmeter.util.JMeterUtils;
@@ -19,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 public class PluginManagerDialogTest {
     @BeforeClass
     public static void setup() {
-        TestJMeterUtils.createJmeterEnv();
+        JMeterTestEnv.createJMeterEnv();
     }
 
     @Test

--- a/src/test/java/org/jmeterplugins/repository/PluginManagerMenuCreatorTest.java
+++ b/src/test/java/org/jmeterplugins/repository/PluginManagerMenuCreatorTest.java
@@ -1,6 +1,5 @@
 package org.jmeterplugins.repository;
 
-import kg.apc.emulators.TestJMeterUtils;
 import org.apache.jmeter.gui.plugin.MenuCreator;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -13,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 public class PluginManagerMenuCreatorTest {
     @BeforeClass
     public static void setup() {
-        TestJMeterUtils.createJmeterEnv();
+        JMeterTestEnv.createJMeterEnv();
     }
 
     @Test

--- a/src/test/java/org/jmeterplugins/repository/PluginManagerTest.java
+++ b/src/test/java/org/jmeterplugins/repository/PluginManagerTest.java
@@ -1,6 +1,5 @@
 package org.jmeterplugins.repository;
 
-import kg.apc.emulators.TestJMeterUtils;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.jmeter.engine.JMeterEngine;
@@ -10,9 +9,15 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
 import java.net.URL;
 
 import static org.junit.Assert.*;
@@ -21,7 +26,7 @@ public class PluginManagerTest {
 
     @BeforeClass
     public static void setup() {
-        TestJMeterUtils.createJmeterEnv();
+        JMeterTestEnv.createJMeterEnv();
         URL url = PluginManagerTest.class.getResource("/testVirtualPlugin.json");
         JMeterUtils.setProperty("jpgc.repo.address", url.getFile());
         //reset static pmgr
@@ -162,8 +167,22 @@ public class PluginManagerTest {
 
     @Test
     public void testRetryDownload() throws Throwable {
+        // a local stub, so this does not depend on a third-party host being up and truthful
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                byte[] body = "failed on purpose".getBytes();
+                exchange.sendResponseHeaders(500, body.length);
+                try (OutputStream out = exchange.getResponseBody()) {
+                    out.write(body);
+                }
+            }
+        });
+        server.start();
+
         String addr = JMeterUtils.getPropDefault("jpgc.repo.address", "https://jmeter-plugins.org/repo/");
-        JMeterUtils.setProperty("jpgc.repo.address", "http://httpstat.us/500");
+        JMeterUtils.setProperty("jpgc.repo.address", "http://localhost:" + server.getAddress().getPort() + "/");
         PluginManager mgr = new PluginManager();
         long start = System.currentTimeMillis();
         try {
@@ -174,7 +193,9 @@ public class PluginManagerTest {
 
         } finally {
             JMeterUtils.setProperty("jpgc.repo.address", addr);
+            server.stop(0);
         }
+        // one retry, 5s apart, before giving up
         assertTrue(5000 < (System.currentTimeMillis() - start));
     }
 

--- a/src/test/java/org/jmeterplugins/repository/http/StatsReporterTest.java
+++ b/src/test/java/org/jmeterplugins/repository/http/StatsReporterTest.java
@@ -1,6 +1,6 @@
 package org.jmeterplugins.repository.http;
 
-import kg.apc.emulators.TestJMeterUtils;
+import org.jmeterplugins.repository.JMeterTestEnv;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -24,7 +24,7 @@ import static org.junit.Assert.*;
 public class StatsReporterTest {
     @BeforeClass
     public static void setup() {
-        TestJMeterUtils.createJmeterEnv();
+        JMeterTestEnv.createJMeterEnv();
     }
 
     @Test

--- a/src/test/java/org/jmeterplugins/repository/logging/LoggerAppenderTest.java
+++ b/src/test/java/org/jmeterplugins/repository/logging/LoggerAppenderTest.java
@@ -1,7 +1,7 @@
 package org.jmeterplugins.repository.logging;
 
 
-import kg.apc.emulators.TestJMeterUtils;
+import org.jmeterplugins.repository.JMeterTestEnv;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
@@ -20,7 +20,7 @@ public class LoggerAppenderTest {
 
     @BeforeClass
     public static void setup() {
-        TestJMeterUtils.createJmeterEnv();
+        JMeterTestEnv.createJMeterEnv();
         URL url = PluginManagerTest.class.getResource("/testVirtualPlugin.json");
         JMeterUtils.setProperty("jpgc.repo.address", url.getFile());
     }

--- a/src/test/java/org/jmeterplugins/repository/logging/LoggerPanelWrappingTest.java
+++ b/src/test/java/org/jmeterplugins/repository/logging/LoggerPanelWrappingTest.java
@@ -1,6 +1,6 @@
 package org.jmeterplugins.repository.logging;
 
-import kg.apc.emulators.TestJMeterUtils;
+import org.jmeterplugins.repository.JMeterTestEnv;
 import org.apache.jmeter.util.JMeterUtils;
 import org.apache.log.LogEvent;
 import org.jmeterplugins.repository.PluginManager;
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 public class LoggerPanelWrappingTest {
     @BeforeClass
     public static void setup() {
-        TestJMeterUtils.createJmeterEnv();
+        JMeterTestEnv.createJMeterEnv();
         URL url = PluginManagerTest.class.getResource("/testVirtualPlugin.json");
         JMeterUtils.setProperty("jpgc.repo.address", url.getFile());
     }

--- a/src/test/java/org/jmeterplugins/repository/logging/LoggingHookerTest.java
+++ b/src/test/java/org/jmeterplugins/repository/logging/LoggingHookerTest.java
@@ -1,6 +1,6 @@
 package org.jmeterplugins.repository.logging;
 
-import kg.apc.emulators.TestJMeterUtils;
+import org.jmeterplugins.repository.JMeterTestEnv;
 import org.apache.jmeter.util.JMeterUtils;
 import org.jmeterplugins.repository.PluginManager;
 import org.jmeterplugins.repository.PluginManagerTest;
@@ -15,7 +15,7 @@ public class LoggingHookerTest {
 
     @BeforeClass
     public static void setup() {
-        TestJMeterUtils.createJmeterEnv();
+        JMeterTestEnv.createJMeterEnv();
         URL url = PluginManagerTest.class.getResource("/testVirtualPlugin.json");
         JMeterUtils.setProperty("jpgc.repo.address", url.getFile());
     }

--- a/src/test/java/org/jmeterplugins/repository/plugins/PluginSuggesterTest.java
+++ b/src/test/java/org/jmeterplugins/repository/plugins/PluginSuggesterTest.java
@@ -1,6 +1,6 @@
 package org.jmeterplugins.repository.plugins;
 
-import kg.apc.emulators.TestJMeterUtils;
+import org.jmeterplugins.repository.JMeterTestEnv;
 import org.apache.jmeter.util.JMeterUtils;
 import org.jmeterplugins.repository.Plugin;
 import org.jmeterplugins.repository.PluginManager;
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 public class PluginSuggesterTest {
     @BeforeClass
     public static void setup() {
-        TestJMeterUtils.createJmeterEnv();
+        JMeterTestEnv.createJMeterEnv();
     }
 
 

--- a/src/test/java/org/jmeterplugins/repository/plugins/SuggestDialogTest.java
+++ b/src/test/java/org/jmeterplugins/repository/plugins/SuggestDialogTest.java
@@ -1,6 +1,6 @@
 package org.jmeterplugins.repository.plugins;
 
-import kg.apc.emulators.TestJMeterUtils;
+import org.jmeterplugins.repository.JMeterTestEnv;
 import org.jmeterplugins.repository.PluginManager;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -13,7 +13,7 @@ public class SuggestDialogTest {
 
     @BeforeClass
     public static void setup() {
-        TestJMeterUtils.createJmeterEnv();
+        JMeterTestEnv.createJMeterEnv();
     }
 
     @Test

--- a/src/test/java/org/jmeterplugins/repository/plugins/TestPlanAnalyzerTest.java
+++ b/src/test/java/org/jmeterplugins/repository/plugins/TestPlanAnalyzerTest.java
@@ -1,6 +1,6 @@
 package org.jmeterplugins.repository.plugins;
 
-import kg.apc.emulators.TestJMeterUtils;
+import org.jmeterplugins.repository.JMeterTestEnv;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -13,7 +13,7 @@ public class TestPlanAnalyzerTest {
 
     @BeforeClass
     public static void setup() {
-        TestJMeterUtils.createJmeterEnv();
+        JMeterTestEnv.createJMeterEnv();
     }
 
     @Test


### PR DESCRIPTION
The project had no CI — only a `.travis.yml` that has not run in years. This adds GitHub Actions, fixes the test failures it exposed, and refreshes dependencies.

**Status: green on JDK 8, 11, 17 and 21 — 72 tests, 0 failures, 0 errors.**

## The CI

- **Tests + packaging** on a JDK **8 / 11 / 17 / 21** matrix (`mvn -B verify` covers both).
- **Shaded-jar assertion** — fails if relocated gson is missing, or if an unrelocated `com.google.gson` leaks in. Guards what #74 set up.
- **Coverage** into the Actions run summary as a table, plus the HTML report as an artifact. Currently **72.2% instructions / 71.1% lines**.
- **Surefire reports** uploaded per JDK.

Coverage goes to the job summary rather than a PR-comment bot — visible in Actions, nothing posted publicly.

## The five failures it found

The first run was red, and it immediately corrected my diagnosis: I had assumed three of the failures were JDK 16+ artifacts, but they failed identically on JDK 8. All five were pre-existing (identical before and after #74), from four causes:

1. **Three failures, one bug.** `jmeter-plugins-emulators` extracts its saveservice properties to `<home>/ss.props` but points `saveservice_properties` at that **absolute** path, while JMeter resolves the property against JMeter home — so `SaveService` looked for `<home><home>/ss.props` and never initialised. `TestPlanAnalyzer.isClassExists` then caught the resulting `NoClassDefFoundError` and reported "class not found" for everything, which is why the analyzer saw 18 and 20 missing classes instead of 4 and 5, and why `PluginManagerCMDTest` could not run. New `JMeterTestEnv` re-points the property relative to home; all test classes go through it. Note 0.5 is the latest emulators release, so this is not fixed upstream.
2. **A second, independent cause on JDK 17/21.** With the properties fixed, the JMeter 2.13-era xstream still could not reflect into `java.base`. Surefire now gets the same `--add-opens` set JMeter's own launcher uses, via a profile activated only on JDK 9+.
3. `ChangesMakerTest` pinned `jmeter-plugins-emulators-0.2.jar` while the pom moved to 0.5. Matched by pattern now, so the next bump will not re-break it.
4. `testRetryDownload` drove its 500 off the third-party `httpstat.us`, which answered *"target server failed to respond"*. Replaced with a local `HttpServer` stub, which also makes the one-retry-5s-apart assertion test our retry logic instead of someone else's uptime.

Surefire is pinned to **3.5.4** — it was resolving to 2.17 locally and 3.5.4 on CI, and that skew is what made an earlier `argLine` experiment look like a no-op.

## Dependency refresh

| | |
|---|---|
| log4j-api | 2.25.5 → 2.26.0 |
| log4j-core | 2.25.4 → 2.26.0 |
| log4j-slf4j-impl | **2.17.0 → 2.26.0** |
| maven-shade-plugin | 3.6.0 → 3.6.2 |
| jacoco-maven-plugin | 0.8.12 → 0.8.15 |
| central-publishing-maven-plugin | 0.7.0 → 0.11.0 |

The three log4j artifacts had drifted — dependabot was bumping `core` and `api` while the slf4j binding sat two years behind on 2.17.0. Also fixes the README, which still pointed at cmdrunner 2.2.1.

Already latest: `jmeter-plugins-emulators` 0.5, `cmdrunner` 2.3, `gson` 2.14.0.

Not bumped on purpose:
- **surefire** — 3.6.0-M1 is a milestone; 3.5.4 is latest stable.
- **darklaf-property-loader 2.3.0** — `provided` scope, and JMeter 5.5 ships 2.7.3. Compiling against 3.1.1 would risk calling an API the host does not have; compiling low is the safe direction for a provided dependency.
- **ApacheJMeter_core / _http 2.13** — bumping to 5.6.3 would raise the minimum supported JMeter, for the tool whose job is bootstrapping plugins into whatever JMeter the user already has. That is a support-floor decision, not hygiene.
- **oss-parent 9** — it is what was silently supplying surefire 2.17. Dropping it touches the release setup.

## Not fixed here

`TestPlanAnalyzer.isClassExists` catches `NoClassDefFoundError` and reports "class absent", conflating "not present" with "present but failed to initialise". That is what turned one missing properties file into "all 18 classes are missing", and it would behave the same in a real JMeter where `SaveService` fails for any reason — the suggester would tell the user every element of their test plan needs a plugin. Product code, so left for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)