### PR TITLE
Stop recompiling the lib-lookup regex per classpath entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.4</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- PluginManagerDialogTest.displayGUI opens the real dialog and waits for
+                             a human to close it when a display is available. That is fine as a manual
+                             check, but it hangs `mvn test` on any developer machine while passing on
+                             CI, which is headless. Make local runs behave like CI. -->
+                        <java.awt.headless>true</java.awt.headless>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/jmeterplugins/repository/Plugin.java
+++ b/src/main/java/org/jmeterplugins/repository/Plugin.java
@@ -26,6 +26,9 @@ import java.util.regex.Pattern;
 public class Plugin {
     private static final Logger log = LoggerFactory.getLogger(Plugin.class);
     private static final Pattern dependsParser = Pattern.compile("([^=<>]+)([=<>]+[0-9.]+)?");
+    private static final Pattern versionInPath = Pattern.compile("-v?([\\.0-9a-zA-Z]+(-[\\w]+)?).jar");
+    private static String cachedClassPath;
+    private static String[] cachedClassPathEntries;
     public static final String VER_STOCK = "0.0.0-STOCK";
     protected JsonObject versions = new JsonObject();
     protected String id;
@@ -215,8 +218,7 @@ public class Plugin {
     }
 
     public static String getVersionFromPath(String installedPath) {
-        Pattern p = Pattern.compile("-v?([\\.0-9a-zA-Z]+(-[\\w]+)?).jar");
-        Matcher m = p.matcher(installedPath);
+        Matcher m = versionInPath.matcher(installedPath);
         if (m.find()) {
             return m.group(1);
         }
@@ -246,17 +248,27 @@ public class Plugin {
     }
 
     public static String getLibInstallPath(String lib) {
-        String[] cp = System.getProperty(DependencyResolver.JAVA_CLASS_PATH).split(File.pathSeparator);
-        String path = getLibPath(lib, cp);
-        if (path != null) return path;
-        return null;
+        return getLibPath(lib, getClassPathEntries());
+    }
+
+    /**
+     * The classpath does not change while we run, but this is called once per library per
+     * dependency resolution - and resolution reruns on every checkbox the user ticks.
+     */
+    private static synchronized String[] getClassPathEntries() {
+        String classPath = System.getProperty(DependencyResolver.JAVA_CLASS_PATH);
+        if (!classPath.equals(cachedClassPath)) {
+            cachedClassPath = classPath;
+            cachedClassPathEntries = classPath.split(File.pathSeparator);
+        }
+        return cachedClassPathEntries;
     }
 
     public static String getLibPath(String lib, String[] paths) {
+        // compiled once per lookup rather than once per classpath entry
+        Pattern p = Pattern.compile("\\W" + Pattern.quote(lib) + "-([0-9]+\\..+)\\.jar");
         for (String path : paths) {
-            Pattern p = Pattern.compile("\\W" + lib + "-([0-9]+\\..+).jar");
-            Matcher m = p.matcher(path);
-            if (m.find()) {
+            if (p.matcher(path).find()) {
                 log.debug("Found library " + lib + " at " + path);
                 return path;
             }


### PR DESCRIPTION
Item 3, the last of the load-time plan. #74 swapped the parser, #75 added CI, #77 fixed the cache.

Unlike the first two this is **UI lag, not load time** — a different symptom from the one that started this.

## Why

`getLibPath()` compiled its `Pattern` *inside* the loop over classpath entries, so looking up one library against a 155-jar classpath compiled the same regex 155 times. `getLibInstallPath()` also re-split `java.class.path` on every call. Both run once per library per dependency resolution — and resolution reruns on **every checkbox the user ticks**, via `getChangesAsText()`.

## Measured

Time for the UI to recompute its change set after a toggle, against the production repo:

| | before | after |
|---|---|---|
| 1 plugin selected | 3.0 ms | **1.3 ms** |
| 10 plugins selected | 14.4 ms | **6.0 ms** |

Modest in absolute terms in this environment, and I won't oversell it: my earlier 117 ms figure was a synthetic worst case over all 315 lib specs at once, not the real path. The real cost scales with classpath size and with how many plugins are installed, because `detectConflicts()` walks every installed plugin's libraries on every resolve — so a loaded JMeter pays considerably more than this test box does.

## Correctness

Also quoted the library name going into the regex. Unquoted, the dots in a name like `kafka_2.8.2` matched any character, so `kafka_2X8X2-1.0.jar` would have matched. Resolution is unchanged in practice: all **188** library names in the production repo, resolved against a real JMeter 5.5 classpath plus synthetic entries exercising regex metacharacters, byte-identical before and after.

The version-from-path `Pattern` is now a constant too — it was recompiled on every call.

## One unrelated fix, because it bit me

Surefire now forces `java.awt.headless=true`. `PluginManagerDialogTest.displayGUI` opens the real dialog and loops `while (frame.isVisible())` until a human closes it whenever a display is available. It passes on CI only because CI is headless — on a developer machine `mvn test` hangs forever with a modal dialog on screen. It cost me six minutes and a stray window before I spotted it. Local runs now behave like CI.

Happy to split that into its own PR if you'd rather keep this one to the perf change.

## Tests

75 tests, 0 failures. Build time locally is now 18.5 s rather than unbounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)