### PR TITLE
Do not report unloadable classes as missing plugins

### DIFF
--- a/src/main/java/org/jmeterplugins/repository/plugins/TestPlanAnalyzer.java
+++ b/src/main/java/org/jmeterplugins/repository/plugins/TestPlanAnalyzer.java
@@ -141,12 +141,24 @@ public class TestPlanAnalyzer {
         }
     }
 
+    /**
+     * Answers whether a class from the test plan is available to JMeter. Only a genuinely absent
+     * class counts as missing: a class that is present but fails to link, or a failure of
+     * SaveService itself, means we cannot tell - and answering "missing" there would have us
+     * offer the user a plugin for every element of their test plan.
+     *
+     * @return false only when the class is definitely not on the classpath
+     */
     public static boolean isClassExists(String className) {
         try {
             Class.forName(SaveService.aliasToClass(className));
             return true;
-        } catch (ClassNotFoundException | NoClassDefFoundError e) {
+        } catch (ClassNotFoundException e) {
+            log.debug("Class is not available: " + className);
             return false;
+        } catch (LinkageError e) {
+            log.warn("Cannot tell whether class is available, assuming it is: " + className, e);
+            return true;
         }
     }
 }

--- a/src/test/java/org/jmeterplugins/repository/plugins/TestPlanAnalyzerTest.java
+++ b/src/test/java/org/jmeterplugins/repository/plugins/TestPlanAnalyzerTest.java
@@ -16,6 +16,37 @@ public class TestPlanAnalyzerTest {
         JMeterTestEnv.createJMeterEnv();
     }
 
+    /**
+     * Present on the classpath, but cannot be initialised - the case that used to be reported
+     * as "class not found", which made the suggester offer plugins the user already had.
+     */
+    public static class FailsToInitialise {
+        static {
+            if (true) {
+                throw new IllegalStateException("boom");
+            }
+        }
+    }
+
+    @Test
+    public void testExistingClassIsNotReportedMissing() {
+        assertTrue(TestPlanAnalyzer.isClassExists("org.apache.jmeter.save.SaveService"));
+    }
+
+    @Test
+    public void testAbsentClassIsReportedMissing() {
+        assertFalse(TestPlanAnalyzer.isClassExists("no.such.plugin.Component"));
+    }
+
+    @Test
+    public void testUnloadableClassIsNotReportedMissing() {
+        String name = FailsToInitialise.class.getName();
+        // first touch raises ExceptionInInitializerError, later ones NoClassDefFoundError;
+        // neither means the class is absent, so neither may be reported as missing
+        assertTrue(TestPlanAnalyzer.isClassExists(name));
+        assertTrue(TestPlanAnalyzer.isClassExists(name));
+    }
+
     @Test
     public void test() throws Exception {
         String path = getClass().getResource("/testplan.xml").getPath();


### PR DESCRIPTION
The swallow spotted while fixing CI in #75. Product code, so it was left for its own PR.

## The bug

`isClassExists()` caught `NoClassDefFoundError` alongside `ClassNotFoundException` and answered *"class does not exist"* for both. Those are different facts:

- **absent** — genuinely not on the classpath, so the user needs a plugin
- **present but unlinkable** — the class is there and failed to initialise, or `SaveService`, which resolves the alias, is itself broken

`TestPlanAnalyzer` feeds `PluginSuggester`, which pre-ticks whatever it reports (`pmgr.togglePlugins(..., true)`) and opens a modal dialog. So one unrelated failure — a missing `saveservice.properties`, say — became *"every element of your test plan needs a plugin installed"*, offering plugins the user already has.

That is exactly what happened in #75: a single missing properties file made the analyzer report **18** and **20** missing classes instead of 4 and 5.

## A second, worse mode

The **first** touch of a broken `SaveService` raises `ExceptionInInitializerError`, which is *not* a `NoClassDefFoundError` and so was not caught at all. It propagated out of `analyze()` and up through the test-plan load path. Only subsequent calls degraded into the wrong-answer case — which is why this presented as a miscount rather than a crash, depending on what had touched `SaveService` first.

## The fix

Catch `LinkageError`, which covers both, and answer "assume present" with a logged warning. Only `ClassNotFoundException` still means missing. We never invent a suggestion from a fact we do not have, and the abnormal condition is logged rather than silently absorbed.

Verified against a JVM with a deliberately broken `SaveService`, analysing the two test plans in the suite:

| | result |
|---|---|
| before | `ExceptionInInitializerError`, analysis aborts — or 18 and 20 classes wrongly reported missing once initialised |
| after | **0** classes reported missing, one warning logged per class |

## Tests

78 tests (3 new), 0 failures. The new cases cover a class that exists, one that does not, and one that is present but throws from its static initialiser — asserted twice, since the first touch and later touches raise different errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)