### PR TITLE
Stop testing error paths against a third-party host

### DIFF
--- a/src/test/java/org/jmeterplugins/repository/FailingHttpStub.java
+++ b/src/test/java/org/jmeterplugins/repository/FailingHttpStub.java
@@ -1,0 +1,49 @@
+package org.jmeterplugins.repository;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+/**
+ * A local endpoint that always answers 500, for exercising the repository and download
+ * failure paths.
+ * <p>
+ * These tests used to point at the public httpstat.us service, which made the suite depend on
+ * a third party being reachable and honest about its status codes, fail outright when offline,
+ * and spend minutes per run inside connect timeouts and retry waits - 221 of the 230 seconds
+ * of one local run. A loopback server answers instantly and always.
+ */
+class FailingHttpStub implements Closeable {
+
+    private final HttpServer server;
+
+    FailingHttpStub() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                byte[] body = "failed on purpose".getBytes();
+                exchange.sendResponseHeaders(500, body.length);
+                try (OutputStream out = exchange.getResponseBody()) {
+                    out.write(body);
+                }
+            }
+        });
+        server.start();
+    }
+
+    /** Port is picked by the OS, so this has to be read rather than assumed. */
+    String url() {
+        return "http://localhost:" + server.getAddress().getPort() + "/";
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+}

--- a/src/test/java/org/jmeterplugins/repository/PluginManagerDialogTest.java
+++ b/src/test/java/org/jmeterplugins/repository/PluginManagerDialogTest.java
@@ -49,8 +49,9 @@ public class PluginManagerDialogTest {
     public void testFailDownload() throws Exception {
         if (!GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance()) {
             String addr = JMeterUtils.getPropDefault("jpgc.repo.address", "https://jmeter-plugins.org/repo/");
+            FailingHttpStub failing = new FailingHttpStub();
             try {
-                JMeterUtils.setProperty("jpgc.repo.address", "http://httpstat.us/500");
+                JMeterUtils.setProperty("jpgc.repo.address", failing.url());
                 PluginManager aManager = new PluginManager();
                 PluginManagerDialog frame = new PluginManagerDialog(aManager);
                 frame.componentShown(null);
@@ -68,6 +69,7 @@ public class PluginManagerDialogTest {
                 frame.actionPerformed(null);
             } finally {
                 JMeterUtils.setProperty("jpgc.repo.address", addr);
+                failing.close();
             }
         }
     }

--- a/src/test/java/org/jmeterplugins/repository/PluginManagerTest.java
+++ b/src/test/java/org/jmeterplugins/repository/PluginManagerTest.java
@@ -9,15 +9,9 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
-
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.reflect.Field;
-import java.net.InetSocketAddress;
 import java.net.URL;
 
 import static org.junit.Assert.*;
@@ -103,18 +97,19 @@ public class PluginManagerTest {
 
     @Test
     public void testApplyChanges() throws Exception {
+        FailingHttpStub failing = new FailingHttpStub();
         String imgPath = "file:///" + new File(".").getAbsolutePath() + "/target/classes/org/jmeterplugins/logo.png";
         String str = "{\"id\": 0,  \"markerClass\": \"" + PluginsListTest.class.getName() + "\"," +
                 " \"screenshotUrl\": \"" + imgPath + "\", \"name\": 3, \"description\": 4, \"helpUrl\": 5, \"vendor\": 5, \"installerClass\": \"test\", " +
                 "\"versions\" : { \"0.1\" : { \"changes\": \"fix verified exception1\" }," +
                 "\"0.2\" : { \"changes\": \"fix verified exception1\", \"libs\": {\n" +
-                "          \"jpgc-common\": \"http://httpstat.us/500\"\n" +
+                "          \"jpgc-common\": \"" + failing.url() + "\"\n" +
                 "        }}," +
-                "\"0.3\" : { \"changes\": \"fix verified exception1\", \"downloadUrl\": \"http://httpstat.us/500\" } }}";
+                "\"0.3\" : { \"changes\": \"fix verified exception1\", \"downloadUrl\": \"" + failing.url() + "\" } }}";
 
         String addr = JMeterUtils.getPropDefault("jpgc.repo.address", "https://jmeter-plugins.org/repo/");
         try {
-            JMeterUtils.setProperty("jpgc.repo.address", "http://httpstat.us/500");
+            JMeterUtils.setProperty("jpgc.repo.address", failing.url());
 
             Plugin p = Plugin.fromJSON(JsonParser.parseString(str).getAsJsonObject());
             PluginManager manager = new PluginManager();
@@ -162,27 +157,16 @@ public class PluginManagerTest {
 
         } finally {
             JMeterUtils.setProperty("jpgc.repo.address", addr);
+            failing.close();
         }
     }
 
     @Test
     public void testRetryDownload() throws Throwable {
-        // a local stub, so this does not depend on a third-party host being up and truthful
-        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
-        server.createContext("/", new HttpHandler() {
-            @Override
-            public void handle(HttpExchange exchange) throws IOException {
-                byte[] body = "failed on purpose".getBytes();
-                exchange.sendResponseHeaders(500, body.length);
-                try (OutputStream out = exchange.getResponseBody()) {
-                    out.write(body);
-                }
-            }
-        });
-        server.start();
+        FailingHttpStub server = new FailingHttpStub();
 
         String addr = JMeterUtils.getPropDefault("jpgc.repo.address", "https://jmeter-plugins.org/repo/");
-        JMeterUtils.setProperty("jpgc.repo.address", "http://localhost:" + server.getAddress().getPort() + "/");
+        JMeterUtils.setProperty("jpgc.repo.address", server.url());
         PluginManager mgr = new PluginManager();
         long start = System.currentTimeMillis();
         try {
@@ -193,7 +177,7 @@ public class PluginManagerTest {
 
         } finally {
             JMeterUtils.setProperty("jpgc.repo.address", addr);
-            server.stop(0);
+            server.close();
         }
         // one retry, 5s apart, before giving up
         assertTrue(5000 < (System.currentTimeMillis() - start));


### PR DESCRIPTION
## Why

`PluginManagerTest` and `PluginManagerDialogTest` pointed the repository address and two download URLs at **`http://httpstat.us/500`** — a public third-party service — to exercise the failure paths.

Three problems with that:

- the suite depends on someone else's uptime, and on them being honest about status codes
- it fails outright when offline
- it spends its time inside connect timeouts and retry waits

Measured locally: `PluginManagerTest` alone took **221 of the 230 seconds** of the test phase.

## What changed

`testRetryDownload` already had the right pattern — a loopback `HttpServer` answering 500, with a comment saying exactly why. That is lifted into `FailingHttpStub` and all four sites now use it.

| | before | after |
|---|---|---|
| `PluginManagerTest` | 221.0 s | **22.25 s** |
| whole build | — | 29.75 s |

77 tests, 0 failures.

## What the remaining 22 s is

Not waste. `testRetryDownload` asserts the retry actually waited (`assertTrue(5000 < elapsed)`), and `testApplyChanges` incurs two more waits at the same 5 s interval. That is the production retry behaviour under test.

Lowering it would mean making `HttpRetryStrategy`'s interval a property purely for test speed, which did not seem worth a production knob.