### PR TITLE
Wait for the release to actually publish before declaring success

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,12 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
+                    <!-- The plugin defaults to waiting only until VALIDATED, then prints
+                         "To finish publishing visit ..." whether or not autoPublish is set -
+                         which reads like the release stalled and needs a click, while Central
+                         is in fact already publishing it. Wait for the real end state so the
+                         build's success means the artifacts are published. -->
+                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
## Why

Releasing 2.0 printed this:

```
Uploaded bundle successfully, deploymentId: 91611b91-... Deployment will publish automatically
Waiting until Deployment 91611b91-... is validated
Deployment 91611b91-... has been validated. To finish publishing visit https://central.sonatype.com/publishing/deployments
BUILD SUCCESS
```

Those last two lines contradict each other. The upload says it will publish automatically — `autoPublish` is `true`, and has been since `a235262 Release 1.12` — but the plugin then stops waiting at validation and prints a message that reads like the release needs manual intervention.

It doesn't. The plugin's defaults are:

```
AUTO_PUBLISH_DEFAULT_VALUE = "false"      (we override to true)
WAIT_UNTIL_DEFAULT_VALUE   = "VALIDATED"  (we did not override)
```

That "to finish publishing" line is emitted at the `VALIDATED` stop point whether or not auto-publish is on, so it tells you nothing about what actually happened.

## What changed

`<waitUntil>published</waitUntil>`, so the build blocks until Central reports the deployment published. BUILD SUCCESS then means the artifacts are on Central, rather than meaning they were accepted for processing.

`WaitUntilRequest.isValidValue` upper-cases before `valueOf`, so the lowercase value is fine. Verified present in the effective POM.

## Not verified end-to-end

This only takes effect during `deploy`, so it cannot be exercised without publishing. The next release is the real test.